### PR TITLE
refactor: Replace ScrollArea with div for better styling in SearchRel…

### DIFF
--- a/src/components/books/SearchReleaseDialog.tsx
+++ b/src/components/books/SearchReleaseDialog.tsx
@@ -603,17 +603,17 @@ export function SearchReleaseDialog({
 
             {!dbBook?.ebook_available && (
               <TabsContent value="ebook" className="mt-4">
-                <ScrollArea className="max-h-[60vh] pr-4">
+                <div className="max-h-[60vh] overflow-y-auto pr-2">
                   {renderReleaseResults('ebook', ebookSearchResults, isSearchingEbooks, ebookSearchError)}
-                </ScrollArea>
+                </div>
               </TabsContent>
             )}
 
             {!dbBook?.audiobook_available && (
               <TabsContent value="audiobook" className="mt-4">
-                <ScrollArea className="max-h-[60vh] pr-4">
+                <div className="max-h-[60vh] overflow-y-auto pr-2">
                   {renderReleaseResults('audiobook', audiobookSearchResults, isSearchingAudiobooks, audiobookSearchError)}
-                </ScrollArea>
+                </div>
               </TabsContent>
             )}
           </Tabs>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import type { Book } from '@/types/book';
 
 interface SearchGroupedResults {
@@ -44,7 +45,8 @@ export function SearchResults({ results, query, isLoading, isFetched }: SearchRe
   }
 
   return (
-    <div className="absolute top-full left-0 right-0 mt-2 rounded-lg bg-popover border border-border shadow-xl overflow-hidden max-h-[70vh] overflow-y-auto z-50 overscroll-contain">
+    <div className="absolute top-full left-0 right-0 mt-2 rounded-lg bg-popover border border-border shadow-xl z-50">
+      <ScrollArea className="max-h-[60vh]">
       {results.series.length > 0 && (
         <div className="border-b border-border/60">
           <div className="px-3 pt-3 pb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -117,6 +119,7 @@ export function SearchResults({ results, query, isLoading, isFetched }: SearchRe
           ))}
         </div>
       )}
+      </ScrollArea>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fix scroll issues in the search release dialog and header search results dropdown.

## Changes

- Replace `ScrollArea` component with a plain `div` using `overflow-y-auto` in `SearchReleaseDialog` for better scroll behavior when browsing indexer results
- Integrate `ScrollArea` in `SearchResults` component for consistent styling in the header search dropdown

## Test plan

- [x] Open the search release dialog on a book with many results
- [x] Verify the results list scrolls properly within the dialog
- [x] Verify the header search dropdown scrolls correctly with many results
