### PR TITLE
fix: Extract torrent hash before adding to qBittorrent

### DIFF
--- a/backend/app/downloads/clients/qbittorrent.py
+++ b/backend/app/downloads/clients/qbittorrent.py
@@ -5,9 +5,10 @@ Provides downloading capabilities for torrent files via qBittorrent Web API.
 """
 import time
 import hashlib
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 from pathlib import Path
 import structlog
+import requests
 
 try:
     from qbittorrentapi import Client as QBClient
@@ -29,6 +30,116 @@ except ImportError:
 from ..import DownloadState
 
 logger = structlog.get_logger()
+
+
+def _bdecode(data: bytes, index: int = 0) -> Tuple[Any, int]:
+    """
+    Decode bencoded data.
+
+    Args:
+        data: Bencoded bytes
+        index: Starting index
+
+    Returns:
+        Tuple of (decoded value, next index)
+    """
+    if data[index:index+1] == b'i':
+        # Integer: i<number>e
+        end = data.index(b'e', index)
+        return int(data[index+1:end]), end + 1
+    elif data[index:index+1] == b'l':
+        # List: l<items>e
+        index += 1
+        result = []
+        while data[index:index+1] != b'e':
+            item, index = _bdecode(data, index)
+            result.append(item)
+        return result, index + 1
+    elif data[index:index+1] == b'd':
+        # Dictionary: d<key><value>...e
+        index += 1
+        result = {}
+        while data[index:index+1] != b'e':
+            key, index = _bdecode(data, index)
+            if isinstance(key, bytes):
+                key = key.decode('utf-8', errors='replace')
+            value, index = _bdecode(data, index)
+            result[key] = value
+        return result, index + 1
+    elif data[index:index+1].isdigit():
+        # String: <length>:<content>
+        colon = data.index(b':', index)
+        length = int(data[index:colon])
+        start = colon + 1
+        return data[start:start+length], start + length
+    else:
+        raise ValueError(f"Invalid bencode at index {index}: {data[index:index+10]}")
+
+
+def _bencode(data: Any) -> bytes:
+    """
+    Encode data to bencode format.
+
+    Args:
+        data: Data to encode (dict, list, int, bytes, or str)
+
+    Returns:
+        Bencoded bytes
+    """
+    if isinstance(data, int):
+        return f"i{data}e".encode()
+    elif isinstance(data, bytes):
+        return f"{len(data)}:".encode() + data
+    elif isinstance(data, str):
+        encoded = data.encode('utf-8')
+        return f"{len(encoded)}:".encode() + encoded
+    elif isinstance(data, list):
+        return b'l' + b''.join(_bencode(item) for item in data) + b'e'
+    elif isinstance(data, dict):
+        # Keys must be sorted
+        result = b'd'
+        for key in sorted(data.keys()):
+            if isinstance(key, str):
+                key_bytes = key.encode('utf-8')
+            else:
+                key_bytes = key
+            result += f"{len(key_bytes)}:".encode() + key_bytes
+            result += _bencode(data[key])
+        result += b'e'
+        return result
+    else:
+        raise ValueError(f"Cannot bencode type: {type(data)}")
+
+
+def extract_info_hash_from_torrent(torrent_data: bytes) -> Optional[str]:
+    """
+    Extract info_hash from torrent file bytes.
+
+    The info_hash is the SHA1 hash of the bencoded 'info' dictionary.
+
+    Args:
+        torrent_data: Raw torrent file bytes
+
+    Returns:
+        40-character lowercase hex hash, or None if extraction fails
+    """
+    try:
+        decoded, _ = _bdecode(torrent_data)
+        if not isinstance(decoded, dict) or 'info' not in decoded:
+            logger.warning("torrent_missing_info_dict")
+            return None
+
+        # Re-encode the info dict and hash it
+        info_dict = decoded['info']
+        info_bencoded = _bencode(info_dict)
+        info_hash = hashlib.sha1(info_bencoded).hexdigest().lower()
+
+        logger.debug("torrent_info_hash_extracted", hash=info_hash)
+        return info_hash
+
+    except Exception as e:
+        logger.warning("torrent_hash_extraction_failed", error=str(e))
+        return None
 
 
 class QBittorrentClient:
@@ -143,6 +254,57 @@ class QBittorrentClient:
             logger.warning("qbittorrent_test_failed", error=str(e))
             return False
 
+    def _download_torrent_file(self, url: str, timeout: int = 30) -> Optional[bytes]:
+        """
+        Download a .torrent file from a URL.
+
+        Args:
+            url: URL to the torrent file (e.g., Prowlarr download URL)
+            timeout: Request timeout in seconds
+
+        Returns:
+            Torrent file bytes, or None if download fails
+        """
+        try:
+            logger.info("downloading_torrent_file", url=url[:100])
+
+            response = requests.get(
+                url,
+                timeout=timeout,
+                headers={
+                    'User-Agent': 'Bookkeep/1.0',
+                    'Accept': 'application/x-bittorrent, */*',
+                },
+                allow_redirects=True,
+            )
+            response.raise_for_status()
+
+            content_type = response.headers.get('Content-Type', '').lower()
+            content = response.content
+
+            # Verify this looks like a torrent file (starts with 'd' for bencoded dict)
+            if not content or content[0:1] != b'd':
+                logger.warning(
+                    "torrent_file_invalid_content",
+                    content_type=content_type,
+                    first_bytes=content[:20] if content else None
+                )
+                return None
+
+            logger.info(
+                "torrent_file_downloaded",
+                size=len(content),
+                content_type=content_type
+            )
+            return content
+
+        except requests.RequestException as e:
+            logger.error("torrent_file_download_failed", url=url[:100], error=str(e))
+            return None
+        except Exception as e:
+            logger.error("torrent_file_download_error", url=url[:100], error=str(e))
+            return None
+
     def add_torrent(
         self,
         url: Optional[str] = None,
@@ -154,6 +316,21 @@ class QBittorrentClient:
     ) -> Optional[str]:
         """
         Add a torrent to qBittorrent.
+
+        This method extracts the info_hash BEFORE adding the torrent to qBittorrent,
+        following the approach used by Readarr/Sonarr. This ensures reliable tracking
+        of torrents without relying on tag-based lookups.
+
+        For URL downloads:
+        1. Download the .torrent file
+        2. Extract info_hash from the file
+        3. Add torrent file bytes to qBittorrent
+        4. Verify torrent appears with known hash
+
+        For magnet links:
+        1. Extract info_hash from magnet link
+        2. Add magnet to qBittorrent
+        3. Verify torrent appears with known hash
 
         Args:
             url: Torrent file URL
@@ -173,6 +350,41 @@ class QBittorrentClient:
         if category is None:
             category = self.category
 
+        # --- Phase 1: Extract hash BEFORE adding ---
+        info_hash = None
+        torrent_data = torrent_file  # May be provided directly
+
+        if magnet:
+            # Extract hash from magnet link
+            info_hash = self._extract_hash_from_magnet(magnet)
+            if info_hash:
+                logger.info("qbittorrent_hash_from_magnet", hash=info_hash)
+            else:
+                logger.warning("qbittorrent_magnet_hash_extraction_failed")
+
+        elif url:
+            # Download the .torrent file and extract hash
+            torrent_data = self._download_torrent_file(url)
+            if torrent_data:
+                info_hash = extract_info_hash_from_torrent(torrent_data)
+                if info_hash:
+                    logger.info("qbittorrent_hash_from_torrent_file", hash=info_hash, url=url[:100])
+                else:
+                    logger.warning("qbittorrent_torrent_file_hash_extraction_failed", url=url[:100])
+            else:
+                logger.error("qbittorrent_torrent_file_download_failed", url=url[:100])
+                # Fall back to passing URL directly to qBittorrent (legacy behavior)
+                logger.info("qbittorrent_falling_back_to_url_add", url=url[:100])
+
+        elif torrent_file:
+            # Extract hash from provided torrent file bytes
+            info_hash = extract_info_hash_from_torrent(torrent_file)
+            if info_hash:
+                logger.info("qbittorrent_hash_from_torrent_bytes", hash=info_hash)
+            else:
+                logger.warning("qbittorrent_torrent_bytes_hash_extraction_failed")
+
+        # --- Phase 2: Add torrent to qBittorrent ---
         try:
             # Prepare add parameters
             add_params = {}
@@ -185,44 +397,107 @@ class QBittorrentClient:
             if tags:
                 add_params['tags'] = tags
 
-            # Add torrent
-            if url:
-                logger.info("qbittorrent_add_url", url=url, category=category)
-                result = self.client.torrents_add(urls=url, **add_params)
-            elif magnet:
-                logger.info("qbittorrent_add_magnet", category=category)
+            # Add torrent - prefer torrent file bytes over URL when available
+            if magnet:
+                logger.info("qbittorrent_add_magnet", category=category, hash=info_hash)
                 result = self.client.torrents_add(urls=magnet, **add_params)
-            elif torrent_file:
-                logger.info("qbittorrent_add_file", category=category)
-                result = self.client.torrents_add(torrent_files=torrent_file, **add_params)
+            elif torrent_data:
+                # We have torrent file bytes (either downloaded or provided)
+                logger.info("qbittorrent_add_file", category=category, hash=info_hash)
+                result = self.client.torrents_add(torrent_files=torrent_data, **add_params)
+            elif url:
+                # Fallback: pass URL directly (less reliable for tracking)
+                logger.info("qbittorrent_add_url", url=url[:100], category=category)
+                result = self.client.torrents_add(urls=url, **add_params)
+            else:
+                logger.error("qbittorrent_no_torrent_source")
+                return None
 
             # qBittorrent returns "Ok." on success
             if result != "Ok.":
                 logger.warning("qbittorrent_add_unexpected_response", result=result)
                 return None
 
-            # Wait a moment for torrent to be added
-            time.sleep(0.5)
-
-            # Get the torrent hash (pass tags to enable tag-based lookup)
-            info_hash = self._get_torrent_hash(url, magnet, torrent_file, category, tags)
-
+            # --- Phase 3: Verify torrent was added ---
             if info_hash:
-                logger.info("qbittorrent_torrent_added", info_hash=info_hash)
+                # We know the hash - verify it appears in qBittorrent
+                if self._wait_for_torrent(info_hash):
+                    logger.info("qbittorrent_torrent_added", info_hash=info_hash)
+                    return info_hash
+                else:
+                    # Torrent may still have been added, return the hash anyway
+                    # (following Readarr's optimistic approach)
+                    logger.warning(
+                        "qbittorrent_torrent_not_verified",
+                        info_hash=info_hash,
+                        message="Torrent may have been added but could not be verified"
+                    )
+                    return info_hash
             else:
-                logger.warning("qbittorrent_torrent_hash_not_found")
-
-            return info_hash
+                # No hash available - fall back to tag-based lookup (legacy)
+                logger.warning("qbittorrent_no_precomputed_hash_falling_back_to_tags")
+                time.sleep(0.5)
+                info_hash = self._get_torrent_hash(url, magnet, torrent_file, category, tags)
+                if info_hash:
+                    logger.info("qbittorrent_torrent_added", info_hash=info_hash)
+                else:
+                    logger.warning("qbittorrent_torrent_hash_not_found")
+                return info_hash
 
         except Conflict409Error:
             # Torrent already exists
-            logger.info("qbittorrent_torrent_exists")
-            info_hash = self._get_torrent_hash(url, magnet, torrent_file, category, tags)
-            return info_hash
+            logger.info("qbittorrent_torrent_exists", info_hash=info_hash)
+            if info_hash:
+                return info_hash
+            # Fall back to tag-based lookup
+            return self._get_torrent_hash(url, magnet, torrent_file, category, tags)
 
         except Exception as e:
             logger.error("qbittorrent_add_failed", error=str(e))
             return None
+
+    def _wait_for_torrent(self, info_hash: str, max_attempts: int = 10, delay: float = 0.1) -> bool:
+        """
+        Wait for a torrent to appear in qBittorrent.
+
+        This follows the Readarr/Sonarr pattern of polling for the torrent
+        with the known hash after adding it.
+
+        Args:
+            info_hash: Expected torrent hash
+            max_attempts: Maximum number of polling attempts
+            delay: Delay between attempts in seconds
+
+        Returns:
+            True if torrent was found, False if timeout
+        """
+        for attempt in range(max_attempts):
+            try:
+                torrents = self.client.torrents_info(torrent_hashes=info_hash.lower())
+                if torrents:
+                    logger.debug(
+                        "qbittorrent_torrent_verified",
+                        hash=info_hash,
+                        attempt=attempt + 1
+                    )
+                    return True
+            except Exception as e:
+                logger.debug(
+                    "qbittorrent_verification_attempt_failed",
+                    hash=info_hash,
+                    attempt=attempt + 1,
+                    error=str(e)
+                )
+
+            if attempt < max_attempts - 1:
+                time.sleep(delay)
+
+        logger.warning(
+            "qbittorrent_torrent_verification_timeout",
+            hash=info_hash,
+            max_attempts=max_attempts
+        )
+        return False
 
     def _ensure_category(self, category: str):
         """Ensure category exists, create if not"""

--- a/backend/tests/downloads/test_qbittorrent_client.py
+++ b/backend/tests/downloads/test_qbittorrent_client.py
@@ -5,11 +5,17 @@ Tests the QBittorrentClient implementation which handles torrent downloads
 via the qBittorrent Web API.
 """
 import pytest
+import hashlib
 from unittest.mock import Mock, patch, MagicMock, PropertyMock
 from typing import Dict, Any
 
 from app.downloads import DownloadState
-from app.downloads.clients.qbittorrent import QBittorrentClient
+from app.downloads.clients.qbittorrent import (
+    QBittorrentClient,
+    extract_info_hash_from_torrent,
+    _bdecode,
+    _bencode,
+)
 
 
 @pytest.fixture
@@ -55,6 +61,128 @@ def mock_torrent():
     torrent.num_leechs = 5
     torrent.ratio = 1.5
     return torrent
+
+
+@pytest.fixture
+def sample_torrent_bytes():
+    """
+    Create a valid torrent file structure for testing.
+
+    A torrent file is a bencoded dictionary containing an 'info' dict.
+    The info_hash is SHA1 of the bencoded info dict.
+    """
+    info_dict = {
+        'name': 'Test Book.epub',
+        'piece length': 262144,
+        'pieces': b'\x00' * 20,  # Fake piece hash
+        'length': 1024000,
+    }
+    torrent_dict = {
+        'announce': 'http://tracker.example.com/announce',
+        'info': info_dict,
+    }
+    return _bencode(torrent_dict)
+
+
+class TestBencode:
+    """Test bencode encoding/decoding"""
+
+    def test_bdecode_integer(self):
+        data = b'i42e'
+        result, _ = _bdecode(data)
+        assert result == 42
+
+    def test_bdecode_negative_integer(self):
+        data = b'i-123e'
+        result, _ = _bdecode(data)
+        assert result == -123
+
+    def test_bdecode_string(self):
+        data = b'4:test'
+        result, _ = _bdecode(data)
+        assert result == b'test'
+
+    def test_bdecode_list(self):
+        data = b'l4:testi42ee'
+        result, _ = _bdecode(data)
+        assert result == [b'test', 42]
+
+    def test_bdecode_dict(self):
+        data = b'd3:keyi42ee'
+        result, _ = _bdecode(data)
+        assert result == {'key': 42}
+
+    def test_bdecode_nested(self):
+        # Nested dict: {'info': {'name': 'test.txt'}, 'size': 100}
+        data = b'd4:infod4:name8:test.txte4:sizei100ee'
+        result, _ = _bdecode(data)
+        assert result == {'info': {'name': b'test.txt'}, 'size': 100}
+
+    def test_bencode_integer(self):
+        assert _bencode(42) == b'i42e'
+
+    def test_bencode_string(self):
+        assert _bencode('test') == b'4:test'
+
+    def test_bencode_bytes(self):
+        assert _bencode(b'test') == b'4:test'
+
+    def test_bencode_list(self):
+        assert _bencode([1, 2]) == b'li1ei2ee'
+
+    def test_bencode_dict(self):
+        # Keys are sorted
+        result = _bencode({'b': 1, 'a': 2})
+        assert result == b'd1:ai2e1:bi1ee'
+
+    def test_roundtrip(self):
+        original = {'info': {'name': b'book.epub', 'length': 1024}}
+        encoded = _bencode(original)
+        decoded, _ = _bdecode(encoded)
+        assert decoded == original
+
+
+class TestExtractInfoHash:
+    """Test info_hash extraction from torrent files"""
+
+    def test_extract_hash_from_valid_torrent(self, sample_torrent_bytes):
+        info_hash = extract_info_hash_from_torrent(sample_torrent_bytes)
+
+        assert info_hash is not None
+        assert len(info_hash) == 40  # SHA1 hex is 40 chars
+        assert info_hash == info_hash.lower()  # Should be lowercase
+
+    def test_extract_hash_deterministic(self, sample_torrent_bytes):
+        # Same torrent should always produce same hash
+        hash1 = extract_info_hash_from_torrent(sample_torrent_bytes)
+        hash2 = extract_info_hash_from_torrent(sample_torrent_bytes)
+        assert hash1 == hash2
+
+    def test_extract_hash_missing_info(self):
+        # Torrent without 'info' dict
+        bad_torrent = _bencode({'announce': 'http://example.com'})
+        info_hash = extract_info_hash_from_torrent(bad_torrent)
+        assert info_hash is None
+
+    def test_extract_hash_invalid_data(self):
+        info_hash = extract_info_hash_from_torrent(b'not a torrent')
+        assert info_hash is None
+
+    def test_extract_hash_empty_data(self):
+        info_hash = extract_info_hash_from_torrent(b'')
+        assert info_hash is None
+
+    def test_extract_hash_matches_manual_calculation(self):
+        # Create a simple torrent and verify hash calculation
+        info_dict = {'name': b'test.txt', 'length': 100, 'piece length': 100, 'pieces': b'\x00' * 20}
+        torrent = _bencode({'info': info_dict})
+
+        # Calculate expected hash manually
+        info_bencoded = _bencode(info_dict)
+        expected_hash = hashlib.sha1(info_bencoded).hexdigest().lower()
+
+        actual_hash = extract_info_hash_from_torrent(torrent)
+        assert actual_hash == expected_hash
 
 
 class TestQBittorrentClientInit:
@@ -193,20 +321,46 @@ class TestTestConnection:
 class TestAddTorrent:
     """Test adding torrents"""
 
-    def test_add_torrent_by_url(self, mock_qb_client):
-        mock_qb_client.client.torrents_add.return_value = "Ok."
-        # Must return torrent when queried by tag
-        mock_qb_client.client.torrents_info.return_value = [Mock(hash="abc123")]
-        mock_qb_client.client.torrents_categories.return_value = {"books": {}}
+    def test_add_torrent_by_url_downloads_file_first(self, mock_qb_client, sample_torrent_bytes):
+        """Test that URL downloads fetch the torrent file first to extract hash"""
+        expected_hash = extract_info_hash_from_torrent(sample_torrent_bytes)
 
-        # Use tags for reliable hash lookup
-        info_hash = mock_qb_client.add_torrent(
-            url="http://example.com/book.torrent",
-            tags=["bookkeep-test"]
-        )
+        # Mock the torrent file download
+        with patch.object(mock_qb_client, '_download_torrent_file', return_value=sample_torrent_bytes):
+            mock_qb_client.client.torrents_add.return_value = "Ok."
+            mock_qb_client.client.torrents_info.return_value = [Mock(hash=expected_hash)]
+            mock_qb_client.client.torrents_categories.return_value = {"books": {}}
 
-        assert info_hash == "abc123"
-        mock_qb_client.client.torrents_add.assert_called_once()
+            info_hash = mock_qb_client.add_torrent(
+                url="http://example.com/book.torrent",
+                tags=["bookkeep-test"]
+            )
+
+            assert info_hash == expected_hash
+            # Should add torrent file bytes, not URL
+            mock_qb_client.client.torrents_add.assert_called_once()
+            call_kwargs = mock_qb_client.client.torrents_add.call_args.kwargs
+            assert 'torrent_files' in call_kwargs
+
+    def test_add_torrent_by_url_fallback_when_download_fails(self, mock_qb_client):
+        """Test fallback to URL-based add when torrent file download fails"""
+        # Mock failed download
+        with patch.object(mock_qb_client, '_download_torrent_file', return_value=None):
+            mock_qb_client.client.torrents_add.return_value = "Ok."
+            mock_qb_client.client.torrents_info.return_value = [Mock(hash="fallback123")]
+            mock_qb_client.client.torrents_categories.return_value = {"books": {}}
+
+            info_hash = mock_qb_client.add_torrent(
+                url="http://example.com/book.torrent",
+                tags=["bookkeep-test"]
+            )
+
+            # Should still work via fallback
+            assert info_hash == "fallback123"
+            # Should add URL directly as fallback
+            mock_qb_client.client.torrents_add.assert_called_once()
+            call_kwargs = mock_qb_client.client.torrents_add.call_args.kwargs
+            assert 'urls' in call_kwargs or mock_qb_client.client.torrents_add.call_args.args
 
     def test_add_torrent_by_magnet(self, mock_qb_client):
         magnet = "magnet:?xt=urn:btih:ABCDEF1234567890ABCDEF1234567890ABCDEF12&dn=Book"
@@ -755,3 +909,164 @@ class TestEdgeCases:
 
         # Should fallback to save_path
         assert path == "/downloads/books"
+
+
+class TestDownloadTorrentFile:
+    """Test torrent file downloading"""
+
+    def test_download_valid_torrent_file(self, mock_qb_client, sample_torrent_bytes):
+        """Test downloading a valid torrent file"""
+        with patch('app.downloads.clients.qbittorrent.requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.content = sample_torrent_bytes
+            mock_response.headers = {'Content-Type': 'application/x-bittorrent'}
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = mock_qb_client._download_torrent_file("http://example.com/book.torrent")
+
+            assert result == sample_torrent_bytes
+            mock_get.assert_called_once()
+
+    def test_download_invalid_content(self, mock_qb_client):
+        """Test handling of non-torrent content"""
+        with patch('app.downloads.clients.qbittorrent.requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.content = b'<html>Not a torrent</html>'
+            mock_response.headers = {'Content-Type': 'text/html'}
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = mock_qb_client._download_torrent_file("http://example.com/book.torrent")
+
+            # Should return None for invalid content
+            assert result is None
+
+    def test_download_empty_content(self, mock_qb_client):
+        """Test handling of empty response"""
+        with patch('app.downloads.clients.qbittorrent.requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.content = b''
+            mock_response.headers = {}
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = mock_qb_client._download_torrent_file("http://example.com/book.torrent")
+
+            assert result is None
+
+    def test_download_request_error(self, mock_qb_client):
+        """Test handling of request errors"""
+        import requests
+        with patch('app.downloads.clients.qbittorrent.requests.get') as mock_get:
+            mock_get.side_effect = requests.RequestException("Connection failed")
+
+            result = mock_qb_client._download_torrent_file("http://example.com/book.torrent")
+
+            assert result is None
+
+    def test_download_http_error(self, mock_qb_client):
+        """Test handling of HTTP errors"""
+        import requests
+        with patch('app.downloads.clients.qbittorrent.requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+            mock_get.return_value = mock_response
+
+            result = mock_qb_client._download_torrent_file("http://example.com/book.torrent")
+
+            assert result is None
+
+
+class TestWaitForTorrent:
+    """Test torrent verification/waiting"""
+
+    def test_wait_for_torrent_immediate(self, mock_qb_client):
+        """Test torrent found immediately"""
+        mock_qb_client.client.torrents_info.return_value = [Mock(hash="abc123")]
+
+        result = mock_qb_client._wait_for_torrent("abc123")
+
+        assert result is True
+        # Should only call once since found immediately
+        assert mock_qb_client.client.torrents_info.call_count == 1
+
+    def test_wait_for_torrent_after_delay(self, mock_qb_client):
+        """Test torrent found after a few attempts"""
+        # First two calls return empty, third succeeds
+        mock_qb_client.client.torrents_info.side_effect = [
+            [],
+            [],
+            [Mock(hash="abc123")]
+        ]
+
+        result = mock_qb_client._wait_for_torrent("abc123", max_attempts=5, delay=0.01)
+
+        assert result is True
+        assert mock_qb_client.client.torrents_info.call_count == 3
+
+    def test_wait_for_torrent_timeout(self, mock_qb_client):
+        """Test timeout when torrent never appears"""
+        mock_qb_client.client.torrents_info.return_value = []
+
+        result = mock_qb_client._wait_for_torrent("abc123", max_attempts=3, delay=0.01)
+
+        assert result is False
+        assert mock_qb_client.client.torrents_info.call_count == 3
+
+    def test_wait_for_torrent_api_error_recovery(self, mock_qb_client):
+        """Test recovery from API errors during wait"""
+        # First call raises error, second succeeds
+        mock_qb_client.client.torrents_info.side_effect = [
+            Exception("API error"),
+            [Mock(hash="abc123")]
+        ]
+
+        result = mock_qb_client._wait_for_torrent("abc123", max_attempts=5, delay=0.01)
+
+        assert result is True
+
+
+class TestAddTorrentWithPrecomputedHash:
+    """Test the new hash-before-add behavior"""
+
+    def test_add_torrent_magnet_extracts_hash_first(self, mock_qb_client):
+        """Test that magnet link hash is extracted before adding"""
+        expected_hash = "abcdef1234567890abcdef1234567890abcdef12"
+        magnet = f"magnet:?xt=urn:btih:{expected_hash.upper()}&dn=Book"
+
+        mock_qb_client.client.torrents_add.return_value = "Ok."
+        mock_qb_client.client.torrents_info.return_value = [Mock(hash=expected_hash)]
+
+        info_hash = mock_qb_client.add_torrent(magnet=magnet)
+
+        assert info_hash == expected_hash
+        # Verify we query by hash (not tag) for verification
+        mock_qb_client.client.torrents_info.assert_called()
+
+    def test_add_torrent_file_extracts_hash_first(self, mock_qb_client, sample_torrent_bytes):
+        """Test that torrent file hash is extracted before adding"""
+        expected_hash = extract_info_hash_from_torrent(sample_torrent_bytes)
+
+        mock_qb_client.client.torrents_add.return_value = "Ok."
+        mock_qb_client.client.torrents_info.return_value = [Mock(hash=expected_hash)]
+        mock_qb_client.client.torrents_categories.return_value = {}
+
+        info_hash = mock_qb_client.add_torrent(torrent_file=sample_torrent_bytes)
+
+        assert info_hash == expected_hash
+
+    def test_add_torrent_returns_hash_even_if_verification_fails(self, mock_qb_client, sample_torrent_bytes):
+        """Test optimistic return of hash even when verification times out"""
+        expected_hash = extract_info_hash_from_torrent(sample_torrent_bytes)
+
+        mock_qb_client.client.torrents_add.return_value = "Ok."
+        # Verification always fails
+        mock_qb_client.client.torrents_info.return_value = []
+        mock_qb_client.client.torrents_categories.return_value = {}
+
+        with patch.object(mock_qb_client, '_wait_for_torrent', return_value=False):
+            info_hash = mock_qb_client.add_torrent(torrent_file=sample_torrent_bytes)
+
+        # Should still return hash (optimistic like Readarr)
+        assert info_hash == expected_hash


### PR DESCRIPTION
## Summary

- Fixes issue #18 where torrents added via URL (e.g., Prowlarr) could not be tracked because tag-based lookup was unreliable
- Implements a new approach: extract the torrent hash **before** adding to qBittorrent
- For URL downloads, we now download the `.torrent` file first, parse it to extract the info_hash, then add the torrent file bytes

## Changes

- Add bencode parser (`_bdecode`, `_bencode`) for parsing torrent files
- Add `extract_info_hash_from_torrent()` to get SHA1 of info dict
- Add `_download_torrent_file()` to fetch `.torrent` files from URLs
- Add `_wait_for_torrent()` to verify torrent appears by known hash (10 attempts, 100ms each - same as Bookshelf)
- Rewrite `add_torrent()` to extract hash BEFORE adding

## How it works

**Before (unreliable):**
```
URL → qBittorrent (adds) → Try to find by tag → Tag not applied → FAIL
```

**After (reliable):**
```
URL → Download .torrent file → Extract hash → qBittorrent (adds file bytes) → Verify by known hash → SUCCESS
```

## Test plan

- [x] All 86 unit tests pass
- [ ] Test with Prowlarr URL download
- [ ] Test with magnet link download
- [ ] Verify torrent tracking works correctly

Fixes #18