### PR TITLE
fix: Filter search results by available download client protocols

### DIFF
--- a/backend/app/downloads/orchestrator.py
+++ b/backend/app/downloads/orchestrator.py
@@ -22,7 +22,7 @@ from . import (
     list_sources,
     list_handlers,
 )
-from ..models import Book, DownloadTask, AppSettings
+from ..models import Book, DownloadTask, AppSettings, DownloadClient
 from ..database import SessionLocal
 
 logger = structlog.get_logger()
@@ -52,6 +52,42 @@ class DownloadOrchestrator:
         self.db_session = db_session
         self._active_downloads: Dict[int, Event] = {}  # task_id -> cancel_event
         self._download_threads: Dict[int, threading.Thread] = {}
+
+    def get_available_protocols(self, db: Optional[Session] = None) -> List[str]:
+        """
+        Get list of protocols that have enabled download clients configured.
+
+        Args:
+            db: Database session
+
+        Returns:
+            List of available protocols (e.g., ["torrent"], ["torrent", "usenet"])
+        """
+        session = db or self.db_session or SessionLocal()
+        close_session = db is None and self.db_session is None
+
+        try:
+            # Query distinct protocols from enabled download clients
+            enabled_clients = session.query(DownloadClient.protocol).filter(
+                DownloadClient.enabled == True
+            ).distinct().all()
+
+            protocols = [client.protocol for client in enabled_clients if client.protocol]
+
+            logger.debug(
+                "orchestrator_available_protocols",
+                protocols=protocols
+            )
+
+            return protocols
+
+        except Exception as e:
+            logger.error("orchestrator_get_protocols_failed", error=str(e))
+            # Default to torrent if we can't determine (safer fallback)
+            return ["torrent"]
+        finally:
+            if close_session:
+                session.close()
 
     def search_releases(
         self,
@@ -90,10 +126,21 @@ class DownloadOrchestrator:
                 format_type=format_type
             )
 
+            # Filter releases to only include protocols with configured clients
+            available_protocols = self.get_available_protocols(db)
+            total_before_filter = len(releases)
+
+            if available_protocols:
+                releases = [r for r in releases if r.protocol in available_protocols]
+
+            filtered_count = total_before_filter - len(releases)
+
             logger.info(
                 "orchestrator_search_complete",
                 book_id=book.id,
                 releases_found=len(releases),
+                releases_filtered=filtered_count,
+                available_protocols=available_protocols,
                 top_quality=releases[0].quality_score if releases else 0
             )
 

--- a/backend/app/routers/downloads.py
+++ b/backend/app/routers/downloads.py
@@ -181,6 +181,21 @@ async def search_releases(
             format_type=format_type
         )
 
+        # Filter releases to only include protocols with configured clients
+        available_protocols = db.query(DownloadClient.protocol).filter(
+            DownloadClient.enabled == True
+        ).distinct().all()
+        available_protocols = [p.protocol for p in available_protocols if p.protocol]
+
+        if available_protocols:
+            releases = [r for r in releases if r.protocol in available_protocols]
+
+        logger.debug(
+            "search_filtered_by_protocol",
+            available_protocols=available_protocols,
+            releases_after_filter=len(releases)
+        )
+
         # Convert to response format and check if already downloaded
         release_info = []
         for r in releases:


### PR DESCRIPTION
## Summary

Only show releases that match protocols with configured and enabled download clients. This prevents attempting to download usenet releases when only torrent clients are configured (and vice versa).

## Changes

- Add `get_available_protocols()` method to orchestrator to check which protocols have enabled download clients
- Filter search results in `orchestrator.search_releases()` to only include releases matching available protocols
- Filter search results in the `/search/{book_id}` API endpoint
- Add logging for filtered release counts and available protocols

## How it works

1. Query the `DownloadClient` table for distinct protocols where `enabled=True`
2. Filter search results to only include releases where `release.protocol` is in the available protocols list
3. This filtering happens in both:
   - The search API endpoint (manual search in UI)
   - The orchestrator's search_releases method (auto-download flow)

## Test plan

- [x] Configure only torrent clients (no usenet)
- [x] Search for a book - should only show torrent results
- [x] Request a book - should only attempt torrent downloads
- [x] Add a usenet client and verify usenet results now appear