### PR TITLE
fix: Use format-specific qBittorrent categories for ebook/audiobook downloads

### DIFF
--- a/backend/app/downloads/clients/qbittorrent.py
+++ b/backend/app/downloads/clients/qbittorrent.py
@@ -162,6 +162,8 @@ class QBittorrentClient:
         password: Optional[str] = None,
         use_ssl: bool = False,
         category: Optional[str] = None,
+        ebook_category: Optional[str] = None,
+        audiobook_category: Optional[str] = None,
         path_mappings: Optional[Dict[str, str]] = None,
     ):
         """
@@ -173,7 +175,9 @@ class QBittorrentClient:
             username: Web UI username
             password: Web UI password
             use_ssl: Use HTTPS connection
-            category: Default category for downloads
+            category: Default/fallback category for downloads
+            ebook_category: Category for ebook downloads (falls back to category)
+            audiobook_category: Category for audiobook downloads (falls back to category)
             path_mappings: Docker path mappings {"container_path": "host_path"}
         """
         if not HAS_QBITTORRENT:
@@ -188,11 +192,29 @@ class QBittorrentClient:
         self.password = password
         self.use_ssl = use_ssl
         self.category = category
+        self.ebook_category = ebook_category
+        self.audiobook_category = audiobook_category
         self.path_mappings = path_mappings or {}
 
         # Initialize client
         self.client: Optional[QBClient] = None
         self._connect()
+
+    def get_category_for_format(self, format_type: Optional[str] = None) -> Optional[str]:
+        """
+        Get the appropriate category based on download format.
+
+        Args:
+            format_type: "ebook", "audiobook", or None
+
+        Returns:
+            The format-specific category, or the default category as fallback
+        """
+        if format_type == "ebook" and self.ebook_category:
+            return self.ebook_category
+        elif format_type == "audiobook" and self.audiobook_category:
+            return self.audiobook_category
+        return self.category
 
     def _connect(self):
         """Establish connection to qBittorrent"""

--- a/backend/app/downloads/handlers/torrent.py
+++ b/backend/app/downloads/handlers/torrent.py
@@ -81,7 +81,7 @@ class TorrentHandler(DownloadHandler):
                         except:
                             pass
 
-                    # Initialize client
+                    # Initialize client with format-specific categories
                     client = QBittorrentClient(
                         host=client_config.host,
                         port=client_config.port,
@@ -89,6 +89,8 @@ class TorrentHandler(DownloadHandler):
                         password=client_config.password,
                         use_ssl=client_config.use_ssl,
                         category=client_config.category,
+                        ebook_category=client_config.ebook_category,
+                        audiobook_category=client_config.audiobook_category,
                         path_mappings=path_mappings,
                     )
 
@@ -179,9 +181,9 @@ class TorrentHandler(DownloadHandler):
                         message="Adding torrent to client"
                     ))
 
-                # Use the client's configured category (from download client settings)
-                # This respects the user's qBittorrent category configuration
-                category = client.category
+                # Select category based on format (ebook/audiobook) with fallback to default
+                # This respects the user's format-specific qBittorrent category configuration
+                category = client.get_category_for_format(task.format)
 
                 # Add torrent with unique tag to identify it later
                 # Use task_id as unique identifier to avoid race conditions


### PR DESCRIPTION
## Summary

Fixes #25 - When downloading ebooks or audiobooks, the system now uses the configured format-specific categories (`ebook_category`, `audiobook_category`) instead of always falling back to the generic category.

## Changes

- Add `ebook_category` and `audiobook_category` parameters to `QBittorrentClient`
- Add `get_category_for_format()` method to select appropriate category based on download format
- Update torrent handler to pass format-specific categories when creating the client
- Update torrent handler to use `get_category_for_format(task.format)` when adding torrents

## How it works

When a download is initiated:
1. The handler gets the format from `task.format` (either "ebook" or "audiobook")
2. Calls `client.get_category_for_format(task.format)`
3. Returns the format-specific category if configured, otherwise falls back to the default category

## Test plan

- [x] Configure qBittorrent with separate categories for ebooks and audiobooks
- [x] Request a book in "both" formats
- [x] Verify ebook goes to ebook category
- [x] Verify audiobook goes to audiobook category