### PR TITLE
ci: Simplify develop branch Docker tag

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -114,9 +114,8 @@ jobs:
               "akiraslingshot/bookkeep:latest")
             app_version="${{ env.new_tag }}"
           elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
-            short_sha=$(git rev-parse --short HEAD)
-            image_tags="akiraslingshot/bookkeep:${{ env.latest_tag }}-develop-${short_sha}"
-            app_version="${{ env.latest_tag }}-develop-${short_sha}"
+            image_tags="akiraslingshot/bookkeep:develop"
+            app_version="develop"
           else
             short_sha=$(git rev-parse --short HEAD)
             image_tags="akiraslingshot/bookkeep:${short_sha}"


### PR DESCRIPTION
## Summary
- Changes the Docker image tag for the develop branch from `{version}-develop-{sha}` to just `develop`
- Makes it simpler to always pull the latest develop build with `docker pull akiraslingshot/bookkeep:develop`

## Test plan
- [x] Merge to develop and verify the image is tagged as `akiraslingshot/bookkeep:develop` on DockerHub