### PR TITLE
Update nzbget.py - New parameter in append for NZBGet v25.3+ 

### DIFF
--- a/backend/app/downloads/clients/nzbget.py
+++ b/backend/app/downloads/clients/nzbget.py
@@ -186,7 +186,8 @@ class NZBGetClient:
                     "",     # DupeKey
                     0,      # DupeScore
                     "SCORE", # DupeMode
-                    {}      # PPParameters
+                    True,    # AutoCategory
+                    [""]      # PPParameters
                 ])
 
             else:
@@ -206,7 +207,8 @@ class NZBGetClient:
                     "",     # DupeKey
                     0,      # DupeScore
                     "SCORE", # DupeMode
-                    {}      # PPParameters
+                    True,    # AutoCategory
+                    [""]      # PPParameters
                 ])
 
             if result and result > 0:


### PR DESCRIPTION
Fixes for NZBGet v25.3+ - Append API takes new parameter "AutoCategory", before PPParameters (which has to be an empty-quoted array) - see https://github.com/nzbgetcom/nzbget/releases/tag/v25.3