### PR TITLE
Add configurable hardlink setting for downloads

### DIFF
--- a/backend/app/downloads/orchestrator.py
+++ b/backend/app/downloads/orchestrator.py
@@ -497,35 +497,58 @@ class DownloadOrchestrator:
                 db.commit()
                 return str(dest_path)
 
-            # Try to hardlink first (fast, no extra space), fall back to copy
-            try:
-                if source.is_file():
-                    # Hardlink single file
-                    os.link(str(source), str(dest_path))
-                    logger.info(
-                        "orchestrator_hardlink_success",
-                        task_id=task.id,
-                        source=str(source),
-                        dest=str(dest_path)
-                    )
-                else:
-                    # For directories, try to hardlink all files
-                    shutil.copytree(str(source), str(dest_path), copy_function=os.link)
-                    logger.info(
-                        "orchestrator_hardlink_dir_success",
-                        task_id=task.id,
-                        source=str(source),
-                        dest=str(dest_path)
-                    )
-            except (OSError, PermissionError) as e:
-                # Hardlink failed (maybe cross-device), fall back to copy
-                logger.info(
-                    "orchestrator_hardlink_failed_copying",
-                    task_id=task.id,
-                    error=str(e),
-                    message="Hardlink failed, falling back to copy"
-                )
+            # Check if hardlinks are enabled (default: true)
+            use_hardlinks_setting = db.query(AppSettings).filter(
+                AppSettings.key == "use_hardlinks"
+            ).first()
+            use_hardlinks = not (use_hardlinks_setting and use_hardlinks_setting.value == "false")
 
+            if use_hardlinks:
+                # Try to hardlink first (fast, no extra space), fall back to copy
+                try:
+                    if source.is_file():
+                        os.link(str(source), str(dest_path))
+                        logger.info(
+                            "orchestrator_hardlink_success",
+                            task_id=task.id,
+                            source=str(source),
+                            dest=str(dest_path)
+                        )
+                    else:
+                        shutil.copytree(str(source), str(dest_path), copy_function=os.link)
+                        logger.info(
+                            "orchestrator_hardlink_dir_success",
+                            task_id=task.id,
+                            source=str(source),
+                            dest=str(dest_path)
+                        )
+                except (OSError, PermissionError) as e:
+                    # Hardlink failed (maybe cross-device), fall back to copy
+                    logger.info(
+                        "orchestrator_hardlink_failed_copying",
+                        task_id=task.id,
+                        error=str(e),
+                        message="Hardlink failed, falling back to copy"
+                    )
+
+                    if source.is_file():
+                        shutil.copy2(str(source), str(dest_path))
+                        logger.info(
+                            "orchestrator_copy_success",
+                            task_id=task.id,
+                            source=str(source),
+                            dest=str(dest_path)
+                        )
+                    else:
+                        shutil.copytree(str(source), str(dest_path))
+                        logger.info(
+                            "orchestrator_copy_dir_success",
+                            task_id=task.id,
+                            source=str(source),
+                            dest=str(dest_path)
+                        )
+            else:
+                # Hardlinks disabled, copy directly
                 if source.is_file():
                     shutil.copy2(str(source), str(dest_path))
                     logger.info(

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -72,10 +72,12 @@ async def set_hardcover_token(
 class DownloadPathsResponse(BaseModel):
     ebook_download_path: Optional[str] = None
     audiobook_download_path: Optional[str] = None
+    use_hardlinks: bool = True
 
 class DownloadPathsUpdate(BaseModel):
     ebook_download_path: Optional[str] = None
     audiobook_download_path: Optional[str] = None
+    use_hardlinks: Optional[bool] = None
 
 def get_setting_value(db: Session, key: str) -> Optional[str]:
     """Get a setting value from database or env var"""
@@ -110,9 +112,13 @@ def set_setting_value(db: Session, key: str, value: Optional[str]):
 @router.get("/download-paths", response_model=DownloadPathsResponse)
 async def get_download_paths(db: Session = Depends(get_db)):
     """Get download paths configuration"""
+    use_hardlinks_val = get_setting_value(db, "use_hardlinks")
+    use_hardlinks = use_hardlinks_val != "false"  # Default to True
+
     return DownloadPathsResponse(
         ebook_download_path=get_setting_value(db, "ebook_download_path"),
-        audiobook_download_path=get_setting_value(db, "audiobook_download_path")
+        audiobook_download_path=get_setting_value(db, "audiobook_download_path"),
+        use_hardlinks=use_hardlinks,
     )
 
 @router.put("/download-paths")
@@ -126,6 +132,9 @@ async def update_download_paths(
 
     if update.audiobook_download_path is not None:
         set_setting_value(db, "audiobook_download_path", update.audiobook_download_path)
+
+    if update.use_hardlinks is not None:
+        set_setting_value(db, "use_hardlinks", "true" if update.use_hardlinks else "false")
 
     return {"message": "Download paths updated successfully"}
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -533,9 +533,9 @@ export const settingsApi = {
     }),
 
   getDownloadPaths: () =>
-    apiRequest<{ ebook_download_path: string | null; audiobook_download_path: string | null }>('/api/settings/download-paths'),
+    apiRequest<{ ebook_download_path: string | null; audiobook_download_path: string | null; use_hardlinks: boolean }>('/api/settings/download-paths'),
 
-  updateDownloadPaths: (paths: { ebook_download_path?: string; audiobook_download_path?: string }) =>
+  updateDownloadPaths: (paths: { ebook_download_path?: string; audiobook_download_path?: string; use_hardlinks?: boolean }) =>
     apiRequest<{ message: string }>('/api/settings/download-paths', {
       method: 'PUT',
       body: JSON.stringify(paths),

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
-import { Save, TestTube, CheckCircle, XCircle, Eye, EyeOff, Lock, Plus, Edit, Trash2, RefreshCw, Play, Clock, Database } from 'lucide-react';
+import { Save, TestTube, CheckCircle, XCircle, Eye, EyeOff, Lock, Plus, Edit, Trash2, RefreshCw, Play, Clock, Database, Link } from 'lucide-react';
 import ProwlarrSettings from '@/components/settings/ProwlarrSettings';
 import DownloadClientsSettings from '@/components/settings/DownloadClientsSettings';
 import DirectoryPicker from '@/components/settings/DirectoryPicker';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -157,6 +158,7 @@ export default function Settings() {
   const [hardcoverToken, setHardcoverToken] = useState('');
   const [ebookDownloadPath, setEbookDownloadPath] = useState('');
   const [audiobookDownloadPath, setAudiobookDownloadPath] = useState('');
+  const [useHardlinks, setUseHardlinks] = useState(true);
   const [clearingCache, setClearingCache] = useState<string | null>(null);
   const [showServerModal, setShowServerModal] = useState(false);
   const [editingServer, setEditingServer] = useState<ReadarrServer | null>(null);
@@ -303,6 +305,7 @@ export default function Settings() {
     if (downloadPaths) {
       setEbookDownloadPath(downloadPaths.ebook_download_path || '');
       setAudiobookDownloadPath(downloadPaths.audiobook_download_path || '');
+      setUseHardlinks(downloadPaths.use_hardlinks);
     }
   }, [downloadPaths]);
 
@@ -325,6 +328,7 @@ export default function Settings() {
     mutationFn: () => settingsApi.updateDownloadPaths({
       ebook_download_path: ebookDownloadPath || undefined,
       audiobook_download_path: audiobookDownloadPath || undefined,
+      use_hardlinks: useHardlinks,
     }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['download-paths'] });
@@ -1081,6 +1085,24 @@ export default function Settings() {
                 <p className="text-xs text-muted-foreground">
                   The directory where audiobooks will be downloaded
                 </p>
+              </div>
+              <div className="flex items-center justify-between rounded-lg border border-border p-4">
+                <div className="space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    <Link className="h-4 w-4 text-muted-foreground" />
+                    <Label htmlFor="use-hardlinks" className="text-foreground font-medium">
+                      Use hardlinks when importing
+                    </Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    When enabled, files are hardlinked to the destination (saves disk space). Disable this if your setup uses separate filesystems, NAS mounts, or Docker volumes where hardlinks are not supported.
+                  </p>
+                </div>
+                <Switch
+                  id="use-hardlinks"
+                  checked={useHardlinks}
+                  onCheckedChange={setUseHardlinks}
+                />
               </div>
               <div className="flex justify-end">
                 <Button


### PR DESCRIPTION
## Summary

- Adds a "Use hardlinks when importing" toggle in **Settings > Download Paths** (default: on)
- When disabled, the orchestrator skips the `os.link()` attempt and copies files directly
- Persisted via `AppSettings` using the existing `use_hardlinks` key

Closes #54

## Changes

- **`backend/app/routers/settings.py`**: Added `use_hardlinks` field to download-paths GET/PUT endpoints
- **`backend/app/downloads/orchestrator.py`**: Reads the setting in `_copy_to_destination()` and conditionally skips hardlinks
- **`src/lib/api.ts`**: Updated download-paths API types to include `use_hardlinks`
- **`src/pages/Settings.tsx`**: Added Switch toggle with description in the Download Paths card

## Screenshot

<img width="1388" height="480" alt="Image" src="https://github.com/user-attachments/assets/6ec28f11-988d-49b9-9665-6967ea210608" />

## Test plan

- [ ] Verify the toggle appears in Settings > Download Paths (default: on)
- [ ] Toggle off, save, reload page, confirm it persists as off
- [ ] Trigger a download with hardlinks off; confirm logs show `orchestrator_copy_success` with no hardlink attempt
- [ ] Toggle on, trigger a download; confirm logs show hardlink attempt as before
- [ ] Run backend tests: `cd backend && pytest -v`