### PR TITLE
fix: Add title validation to Prowlarr release filtering

### DIFF
--- a/backend/app/downloads/prowlarr/source.py
+++ b/backend/app/downloads/prowlarr/source.py
@@ -3,6 +3,7 @@ Prowlarr release source implementation.
 
 Searches for book releases via Prowlarr and returns standardized Release objects.
 """
+import re
 from typing import List, Optional
 import structlog
 
@@ -14,6 +15,7 @@ from .utils import (
     is_audiobook,
     build_search_queries,
     calculate_quality_score,
+    normalize_title,
 )
 
 logger = structlog.get_logger()
@@ -143,7 +145,7 @@ class ProwlarrSource(ReleaseSource):
         # Convert to Release objects with author validation
         releases = []
         for result in all_results:
-            release = self._convert_to_release(result, format_type, author)
+            release = self._convert_to_release(result, format_type, author, title)
             if release:
                 releases.append(release)
 
@@ -163,7 +165,8 @@ class ProwlarrSource(ReleaseSource):
         self,
         prowlarr_result: dict,
         format_type: str,
-        expected_author: Optional[str] = None
+        expected_author: Optional[str] = None,
+        expected_title: Optional[str] = None
     ) -> Optional[Release]:
         """
         Convert Prowlarr result to Release object.
@@ -172,6 +175,7 @@ class ProwlarrSource(ReleaseSource):
             prowlarr_result: Raw result from Prowlarr
             format_type: Expected format type ("ebook" or "audiobook")
             expected_author: Expected author name for validation (optional)
+            expected_title: Expected book title for validation (optional)
 
         Returns:
             Release object or None if invalid
@@ -190,6 +194,15 @@ class ProwlarrSource(ReleaseSource):
                 "prowlarr_author_mismatch",
                 release_title=title[:100],
                 expected_author=expected_author
+            )
+            return None
+
+        # Validate title if provided - prevents grabbing wrong books by same author
+        if expected_title and not self._title_matches(title, expected_title):
+            logger.debug(
+                "prowlarr_title_mismatch",
+                release_title=title[:100],
+                expected_title=expected_title
             )
             return None
 
@@ -301,6 +314,111 @@ class ProwlarrSource(ReleaseSource):
                 return True
 
         return False
+
+    # Stop words excluded when computing word overlap for title matching
+    _STOP_WORDS = frozenset({
+        "the", "a", "an", "and", "or", "of", "in", "on", "at", "to", "for",
+        "is", "it", "by", "with", "from", "as", "but", "not", "no", "be",
+    })
+
+    def _title_matches(self, release_title: str, expected_title: str) -> bool:
+        """
+        Check if a release title matches the expected book title.
+
+        Uses two strategies based on title length:
+        - Short titles (1-2 words): segment-based exact matching to prevent
+          partial matches (e.g. "It" matching "You Like It Darker")
+        - Longer titles (3+ words): substring containment and word overlap
+
+        Args:
+            release_title: The release title from the indexer
+            expected_title: The expected book title
+
+        Returns:
+            True if the title appears to match, False otherwise
+        """
+        if not expected_title:
+            return True
+
+        normalized_release = normalize_title(release_title).lower()
+        normalized_expected = expected_title.lower().strip()
+
+        if not normalized_expected:
+            return True
+
+        # Use total word count to decide strategy (not significant words)
+        is_short_title = len(normalized_expected.split()) <= 2
+
+        if is_short_title:
+            # Short titles only use strict segment matching
+            return self._short_title_matches(normalized_release, normalized_expected)
+
+        # For longer titles, direct substring containment is safe
+        if normalized_expected in normalized_release:
+            return True
+
+        expected_words = [
+            w for w in normalized_expected.split()
+            if w not in self._STOP_WORDS
+        ]
+        return self._long_title_matches(
+            normalized_release, normalized_expected, expected_words
+        )
+
+    def _short_title_matches(
+        self, normalized_release: str, normalized_expected: str
+    ) -> bool:
+        """
+        Match short titles (1-2 words) using strict segment-based matching.
+
+        Splits the release title on common delimiters (" - ", " by ") and checks
+        if any segment exactly equals the expected title. This prevents false
+        positives like "You Like It Darker" matching "It" or "Dune Messiah"
+        matching "Dune".
+        """
+        # Split on common release title delimiters
+        segments = re.split(r'\s+-\s+|\s+by\s+', normalized_release)
+
+        for segment in segments:
+            segment = segment.strip()
+            if not segment:
+                continue
+
+            # Exact segment match (after normalize_title already stripped
+            # format tags, brackets, years, etc.)
+            if segment == normalized_expected:
+                return True
+
+        return False
+
+    def _long_title_matches(
+        self,
+        normalized_release: str,
+        normalized_expected: str,
+        expected_words: list
+    ) -> bool:
+        """
+        Match longer titles (3+ significant words) using word overlap.
+
+        Checks substring containment, subtitle matching, and requires 60%+
+        of significant words to appear in the release.
+        """
+        # Subtitle matching: split on ":" or " - " and check each part
+        subtitle_parts = re.split(r'[:\-]\s*', normalized_expected)
+        for part in subtitle_parts:
+            part = part.strip()
+            if part and part in normalized_release:
+                return True
+
+        # Word overlap: at least 60% of significant words must appear
+        if not expected_words:
+            return True
+
+        release_words = set(normalized_release.split())
+        matched = sum(1 for w in expected_words if w in release_words)
+        ratio = matched / len(expected_words)
+
+        return ratio >= 0.6
 
     def search_by_isbn(self, isbn: str, format_type: str = "ebook") -> List[Release]:
         """

--- a/backend/tests/downloads/test_prowlarr_source.py
+++ b/backend/tests/downloads/test_prowlarr_source.py
@@ -394,7 +394,7 @@ class TestQualitySorting:
         # Return releases with different quality indicators
         mock_prowlarr_source.client.search_with_retry.return_value = [
             {
-                "title": "Book Low Quality.pdf",
+                "title": "Author - The Great Gatsby.pdf",
                 "downloadUrl": "http://download/1",
                 "size": 100000,  # Very small
                 "protocol": "torrent",
@@ -402,7 +402,7 @@ class TestQualitySorting:
                 "categories": [],
             },
             {
-                "title": "Book High Quality [EPUB]",
+                "title": "Author - The Great Gatsby [EPUB]",
                 "downloadUrl": "http://download/2",
                 "size": 5242880,  # 5 MB - good size
                 "protocol": "torrent",
@@ -410,7 +410,7 @@ class TestQualitySorting:
                 "categories": [],
             },
             {
-                "title": "Book Medium Quality [MOBI]",
+                "title": "Author - The Great Gatsby [MOBI]",
                 "downloadUrl": "http://download/3",
                 "size": 3145728,  # 3 MB
                 "protocol": "torrent",
@@ -420,7 +420,7 @@ class TestQualitySorting:
         ]
 
         results = mock_prowlarr_source.search(
-            title="Book",
+            title="The Great Gatsby",
             format_type="ebook"
         )
 
@@ -429,8 +429,8 @@ class TestQualitySorting:
         assert results[0].quality_score >= results[1].quality_score
         assert results[1].quality_score >= results[2].quality_score
 
-        # High quality should be first (EPUB, good size, many seeders)
-        assert "High Quality" in results[0].title
+        # EPUB should rank highest (preferred format, good size, many seeders)
+        assert results[0].format == "epub"
 
 
 class TestEdgeCases:
@@ -568,3 +568,166 @@ class TestIntegrationScenarios:
         assert results[0].format == "m4b"
         assert results[0].metadata["is_audiobook"] is True
         assert results[0].size_bytes == 524288000
+
+
+class TestTitleMatches:
+    """Test title matching logic for release filtering"""
+
+    # --- Short title tests (1-2 significant words) ---
+
+    def test_short_title_rejects_false_positive(self, mock_prowlarr_source):
+        """'It' should NOT match 'You Like It Darker by Stephen King'"""
+        assert mock_prowlarr_source._title_matches(
+            "You Like It Darker by Stephen King", "It"
+        ) is False
+
+    def test_short_title_exact_segment_after_dash(self, mock_prowlarr_source):
+        """'It' should match 'Stephen King - It [EPUB]'"""
+        assert mock_prowlarr_source._title_matches(
+            "Stephen King - It [EPUB]", "It"
+        ) is True
+
+    def test_short_title_exact_segment_before_by(self, mock_prowlarr_source):
+        """'It' should match 'It by Stephen King [EPUB]'"""
+        assert mock_prowlarr_source._title_matches(
+            "It by Stephen King [EPUB]", "It"
+        ) is True
+
+    def test_short_title_direct_containment(self, mock_prowlarr_source):
+        """Direct containment still works for short titles"""
+        assert mock_prowlarr_source._title_matches(
+            "It - Stephen King", "It"
+        ) is True
+
+    def test_short_title_dune(self, mock_prowlarr_source):
+        """'Dune' should match 'Frank Herbert - Dune [EPUB]'"""
+        assert mock_prowlarr_source._title_matches(
+            "Frank Herbert - Dune [EPUB]", "Dune"
+        ) is True
+
+    def test_short_title_dune_rejects_messiah(self, mock_prowlarr_source):
+        """'Dune' should NOT match 'Dune Messiah by Frank Herbert'"""
+        assert mock_prowlarr_source._title_matches(
+            "Dune Messiah by Frank Herbert", "Dune"
+        ) is False
+
+    def test_short_title_two_words(self, mock_prowlarr_source):
+        """Two-word title 'Dark Matter' should match correctly"""
+        assert mock_prowlarr_source._title_matches(
+            "Blake Crouch - Dark Matter [EPUB]", "Dark Matter"
+        ) is True
+
+    # --- Long title tests (3+ significant words) ---
+
+    def test_long_title_direct_containment(self, mock_prowlarr_source):
+        """Full title substring match"""
+        assert mock_prowlarr_source._title_matches(
+            "The Great Gatsby F Scott Fitzgerald [EPUB]", "The Great Gatsby"
+        ) is True
+
+    def test_long_title_subtitle_match(self, mock_prowlarr_source):
+        """Subtitle 'The Final Empire' should match in release"""
+        assert mock_prowlarr_source._title_matches(
+            "Brandon Sanderson - The Final Empire [EPUB]",
+            "Mistborn: The Final Empire"
+        ) is True
+
+    def test_long_title_word_overlap(self, mock_prowlarr_source):
+        """Word overlap >= 60% should match"""
+        assert mock_prowlarr_source._title_matches(
+            "Gatsby Great American Novel", "The Great Gatsby"
+        ) is True
+
+    def test_long_title_insufficient_overlap(self, mock_prowlarr_source):
+        """Word overlap < 60% should NOT match"""
+        assert mock_prowlarr_source._title_matches(
+            "Completely Different Book Title", "The Great Gatsby"
+        ) is False
+
+    # --- Empty/None edge cases ---
+
+    def test_empty_expected_title(self, mock_prowlarr_source):
+        """Empty expected title should always match (no filter)"""
+        assert mock_prowlarr_source._title_matches(
+            "Any Release Title", ""
+        ) is True
+
+    def test_none_expected_title_in_convert(self, mock_prowlarr_source):
+        """No expected_title should skip title validation"""
+        prowlarr_result = {
+            "title": "Any Book [EPUB]",
+            "downloadUrl": "http://download/1",
+            "size": 2048000,
+            "protocol": "torrent",
+            "categories": [],
+        }
+        release = mock_prowlarr_source._convert_to_release(
+            prowlarr_result, "ebook", expected_title=None
+        )
+        assert release is not None
+
+    # --- Integration: _convert_to_release rejects wrong title ---
+
+    def test_convert_rejects_wrong_title(self, mock_prowlarr_source):
+        """_convert_to_release should reject releases with wrong title"""
+        prowlarr_result = {
+            "title": "You Like It Darker by Stephen King [EPUB]",
+            "downloadUrl": "http://download/1",
+            "size": 2048000,
+            "protocol": "torrent",
+            "categories": [{"id": 7000, "name": "Books/Ebook"}],
+        }
+        release = mock_prowlarr_source._convert_to_release(
+            prowlarr_result, "ebook",
+            expected_author="Stephen King",
+            expected_title="It"
+        )
+        assert release is None
+
+    def test_convert_accepts_correct_title(self, mock_prowlarr_source):
+        """_convert_to_release should accept releases with correct title"""
+        prowlarr_result = {
+            "title": "Stephen King - It [EPUB]",
+            "downloadUrl": "http://download/1",
+            "size": 2048000,
+            "protocol": "torrent",
+            "categories": [{"id": 7000, "name": "Books/Ebook"}],
+        }
+        release = mock_prowlarr_source._convert_to_release(
+            prowlarr_result, "ebook",
+            expected_author="Stephen King",
+            expected_title="It"
+        )
+        assert release is not None
+        assert release.title == "Stephen King - It [EPUB]"
+
+    # --- Integration: search() passes title through ---
+
+    def test_search_filters_wrong_titles(self, mock_prowlarr_source):
+        """search() should filter out releases that don't match the title"""
+        mock_prowlarr_source.client.search_with_retry.return_value = [
+            {
+                "title": "Stephen King - It [EPUB]",
+                "downloadUrl": "http://download/1",
+                "size": 2048000,
+                "protocol": "torrent",
+                "categories": [{"id": 7000, "name": "Books/Ebook"}],
+            },
+            {
+                "title": "You Like It Darker by Stephen King [EPUB]",
+                "downloadUrl": "http://download/2",
+                "size": 3048000,
+                "protocol": "torrent",
+                "categories": [{"id": 7000, "name": "Books/Ebook"}],
+            },
+        ]
+
+        results = mock_prowlarr_source.search(
+            title="It",
+            author="Stephen King",
+            format_type="ebook"
+        )
+
+        # Only the correct title should survive
+        assert len(results) == 1
+        assert "Stephen King - It" in results[0].title


### PR DESCRIPTION
## Summary
- Adds `_title_matches()` to `ProwlarrSource` with two strategies based on title length: strict segment matching for short titles (1-2 words) and substring/word-overlap matching for longer titles (3+ words)
- Wires title validation into `_convert_to_release()` alongside the existing author check, preventing wrong books by the same author from being grabbed
- Adds 16 new tests covering short title rejection, long title matching, edge cases, and end-to-end integration through `search()`

Closes #41

## Test plan
- [x] All 315 backend tests pass (`uv run pytest tests/ -v`)
- [x] Manual: search for "It" by Stephen King, confirm "You Like It Darker" releases are filtered out
- [x] Manual: search for a long title (e.g. "The Great Gatsby"), confirm valid releases still pass
- [x] Check logs for `prowlarr_title_mismatch` entries showing filtered releases