### PR TITLE
fix: detect ebook vs audiobook availability per-item from Audiobookshelf

### DIFF
--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -912,6 +912,13 @@ async def sync_from_audiobookshelf():
             media = item.get("media", {})
             metadata = media.get("metadata", {})
 
+            # Audiobookshelf reports per-item whether audio and/or ebook
+            # content actually exists -- don't assume every item is an
+            # audiobook just because it came from an Audiobookshelf sync.
+            has_audio = (media.get("numAudioFiles") or 0) > 0
+            has_ebook = bool(media.get("ebookFormat"))
+            item_formats = [f for f, present in (("audiobook", has_audio), ("ebook", has_ebook)) if present]
+
             title = metadata.get("title") or "Unknown Title"
             author = metadata.get("authorName") or "Unknown Author"
             isbn = metadata.get("isbn")
@@ -920,18 +927,22 @@ async def sync_from_audiobookshelf():
             if item_id:
                 existing_by_abs_id = db.query(Book).filter(Book.audiobookshelf_id == item_id).first()
                 if existing_by_abs_id:
-                    existing_by_abs_id.audiobook_available = True
+                    if has_audio:
+                        existing_by_abs_id.audiobook_available = True
+                    if has_ebook:
+                        existing_by_abs_id.ebook_available = True
                     existing_by_abs_id.last_refreshed = datetime.now(timezone.utc)
                     db.add(existing_by_abs_id)
 
-                    existing_request = db.query(BookRequest).filter(
+                    existing_requests = db.query(BookRequest).filter(
                         BookRequest.book_id == existing_by_abs_id.id,
-                        BookRequest.format == "audiobook"
-                    ).first()
-                    if existing_request and existing_request.status in ("processing", "approved", "pending"):
-                        existing_request.status = "available"
-                        existing_request.updated_at = datetime.now(timezone.utc)
-                        updated_count += 1
+                        BookRequest.format.in_(item_formats)
+                    ).all() if item_formats else []
+                    for existing_request in existing_requests:
+                        if existing_request.status in ("processing", "approved", "pending"):
+                            existing_request.status = "available"
+                            existing_request.updated_at = datetime.now(timezone.utc)
+                            updated_count += 1
 
                     try:
                         db.commit()
@@ -1016,7 +1027,8 @@ async def sync_from_audiobookshelf():
                                     ratings_count=hardcover_data.get("ratings_count"),
                                     users_count=hardcover_data.get("users_count"),
                                     genres=genres or None,
-                                    audiobook_available=True,
+                                    audiobook_available=has_audio,
+                                    ebook_available=has_ebook,
                                 )
                                 db.add(db_book)
                                 try:
@@ -1043,21 +1055,25 @@ async def sync_from_audiobookshelf():
             # Update existing book
             if item_id:
                 db_book.audiobookshelf_id = item_id
-            db_book.audiobook_available = True
+            if has_audio:
+                db_book.audiobook_available = True
+            if has_ebook:
+                db_book.ebook_available = True
             db_book.last_refreshed = datetime.now(timezone.utc)
             db.add(db_book)
             books_updated += 1
 
             # Update matching requests
-            existing_request = db.query(BookRequest).filter(
+            existing_requests = db.query(BookRequest).filter(
                 BookRequest.book_id == db_book.id,
-                BookRequest.format == "audiobook"
-            ).first()
+                BookRequest.format.in_(item_formats)
+            ).all() if item_formats else []
 
-            if existing_request and existing_request.status in ("processing", "approved", "pending"):
-                existing_request.status = "available"
-                existing_request.updated_at = datetime.now(timezone.utc)
-                updated_count += 1
+            for existing_request in existing_requests:
+                if existing_request.status in ("processing", "approved", "pending"):
+                    existing_request.status = "available"
+                    existing_request.updated_at = datetime.now(timezone.utc)
+                    updated_count += 1
 
             try:
                 db.commit()


### PR DESCRIPTION
## Problem
Fixes #88.

`sync_from_audiobookshelf()` unconditionally sets `audiobook_available = True` for every synced item, regardless of what content that item actually contains. For anyone running a combined ebook + audiobook library in Audiobookshelf (or an item that has both an ebook file and audio files), this means:

- Ebook availability is never recorded, even when the ebook file is right there
- Pending ebook requests never auto-resolve to "available"
- The "already have it" indicator is wrong for ebooks in mixed libraries

## Fix
Audiobookshelf already reports this per item on the `media` object — `numAudioFiles` and `ebookFormat` — so the sync now checks both and sets `audiobook_available` / `ebook_available` independently instead of assuming audiobook. Matching `BookRequest` rows are now resolved against whichever formats are actually present on the item, not just `audiobook`.

## Testing
Verified against a real Audiobookshelf instance with a combined library. Before the fix, an item with both an epub and an audio track (Audiobookshelf reports `ebookFormat: epub` and `numAudioFiles: 1` on the same item) was synced with `ebook_available: false, audiobook_available: true`. After the fix, re-running the sync against the same instance correctly produces `ebook_available: true, audiobook_available: true`, and 10-12 existing library records updated correctly with no errors during the run.
