### PR TITLE
fix: correct Prowlarr magnet URL selection and qBittorrent 5.x add response handling

### DIFF
--- a/backend/app/downloads/clients/qbittorrent.py
+++ b/backend/app/downloads/clients/qbittorrent.py
@@ -440,8 +440,22 @@ class QBittorrentClient:
                 logger.error("qbittorrent_no_torrent_source")
                 return None
 
-            # qBittorrent returns "Ok." on success
-            if result != "Ok.":
+            # Older qBittorrent/qbittorrent-api versions return the plain
+            # string "Ok." on success. Newer qBittorrent servers (5.1+, this
+            # instance runs 5.2.3) return a structured TorrentsAddedMetadata
+            # object instead - checking only for the literal string silently
+            # treated every genuine success as a failure once the server was
+            # upgraded.
+            if result == "Ok.":
+                pass  # legacy success response
+            elif hasattr(result, "success_count"):
+                added_ok = (getattr(result, "success_count", 0) or 0) > 0
+                if info_hash and getattr(result, "added_torrent_ids", None):
+                    added_ok = added_ok or info_hash in result.added_torrent_ids
+                if not added_ok:
+                    logger.warning("qbittorrent_add_unexpected_response", result=result)
+                    return None
+            else:
                 logger.warning("qbittorrent_add_unexpected_response", result=result)
                 return None
 

--- a/backend/app/downloads/prowlarr/source.py
+++ b/backend/app/downloads/prowlarr/source.py
@@ -4,6 +4,7 @@ Prowlarr release source implementation.
 Searches for book releases via Prowlarr and returns standardized Release objects.
 """
 import re
+import urllib.parse
 from typing import List, Optional
 import structlog
 
@@ -19,6 +20,18 @@ from .utils import (
 )
 
 logger = structlog.get_logger()
+
+
+def _build_magnet_from_hash(info_hash, title=None):
+    """Build a plain magnet URI from Prowlarr's infoHash field. More reliable
+    than trusting the downloadUrl/magnetUrl field names - both can actually be
+    Prowlarr proxy links (http://.../download?...) rather than a real magnet:
+    URI or direct file, depending on indexer. infoHash is the one field that's
+    consistently the raw torrent hash, not a proxy redirect."""
+    if not info_hash:
+        return None
+    dn = urllib.parse.quote(title) if title else ''
+    return f'magnet:?xt=urn:btih:{info_hash}' + (f'&dn={dn}' if dn else '')
 
 
 @register_source("prowlarr")
@@ -122,8 +135,18 @@ class ProwlarrSource(ReleaseSource):
 
             if results:
                 # Add only unique results (by download URL)
+                # Prowlarr results are either direct-download (downloadUrl) or
+                # magnet-link (magnetUrl) depending on indexer/protocol - most
+                # public torrent indexers (e.g. Pirate Bay via Prowlarr) only
+                # populate magnetUrl, so downloadUrl alone silently drops them.
                 for result in results:
-                    url = result.get("downloadUrl", "")
+                    # Build a real magnet URI from infoHash when available - both
+                    # downloadUrl AND magnetUrl can be Prowlarr proxy redirect
+                    # links depending on indexer, not the raw magnet/file URL
+                    # their names imply.
+                    url = (_build_magnet_from_hash(result.get("infoHash"), result.get("title"))
+                           or result.get("magnetUrl")
+                           or result.get("downloadUrl", ""))
                     if url and url not in seen_urls:
                         seen_urls.add(url)
                         all_results.append(result)
@@ -184,7 +207,9 @@ class ProwlarrSource(ReleaseSource):
         if not title:
             return None
 
-        download_url = prowlarr_result.get("downloadUrl", "")
+        download_url = (_build_magnet_from_hash(prowlarr_result.get("infoHash"), prowlarr_result.get("title"))
+                        or prowlarr_result.get("magnetUrl")
+                        or prowlarr_result.get("downloadUrl", ""))
         if not download_url:
             return None
 


### PR DESCRIPTION
## Summary
Two bugs found while running real torrent-based ebook/audiobook downloads end-to-end against a live instance:

- **Prowlarr magnet URL selection**: search/download results were read from `downloadUrl` only. Several indexers (e.g. public trackers proxied through Prowlarr) leave that field empty or pointing at a Prowlarr proxy redirect rather than a real magnet/file URL, silently dropping otherwise-good results. Now builds a proper magnet URI from the result's `infoHash` field first (the one field that's consistently the raw torrent hash), falling back to `magnetUrl` then `downloadUrl`.
- **qBittorrent 5.x add response handling**: `QBittorrentClient.add_torrent` only recognized the legacy `"Ok."` string response. qBittorrent 5.1+ returns a structured `TorrentsAddedMetadata` object instead, which was being treated as a failure on every single successful add call against a 5.2.3 server.

## Test plan
- [x] Verified against a live Prowlarr instance with multiple indexer types (public torrent trackers via magnet-only results, and results with populated downloadUrl) - confirmed magnet URIs are now built correctly from infoHash when downloadUrl/magnetUrl are proxy links.
- [x] Verified against a live qBittorrent 5.2.3 server - confirmed torrent adds that previously logged as failures now succeed and are correctly tracked.
- [x] Full end-to-end run: Bookkeep search -> Prowlarr -> qBittorrent -> import, for both an ebook and an audiobook release.