### PR TITLE
Add configurable defaults for OIDC user permissions

### DIFF
--- a/backend/app/oidc.py
+++ b/backend/app/oidc.py
@@ -19,11 +19,17 @@ OIDC_SETTING_KEYS = [
     "oidc_redirect_uri",
     "oidc_auto_register",
     "oidc_button_text",
+    "oidc_default_can_download",
+    "oidc_default_auto_approve_ebooks",
+    "oidc_default_auto_approve_audiobooks",
 ]
 
 OIDC_DEFAULTS = {
     "oidc_auto_register": "true",
     "oidc_button_text": "Sign in with SSO",
+    "oidc_default_can_download": "false",
+    "oidc_default_auto_approve_ebooks": "false",
+    "oidc_default_auto_approve_audiobooks": "false",
 }
 
 

--- a/backend/app/routers/oidc.py
+++ b/backend/app/routers/oidc.py
@@ -275,6 +275,17 @@ async def oidc_callback(
             return RedirectResponse(url="/login?error=registration_disabled", status_code=302)
 
         username = preferred_username or f"user_{secrets.token_hex(4)}"
+
+        default_can_download = (
+            (_get_oidc_value(db, "oidc_default_can_download") or "false").lower() == "true"
+        )
+        default_auto_approve_ebooks = (
+            (_get_oidc_value(db, "oidc_default_auto_approve_ebooks") or "false").lower() == "true"
+        )
+        default_auto_approve_audiobooks = (
+            (_get_oidc_value(db, "oidc_default_auto_approve_audiobooks") or "false").lower() == "true"
+        )
+
         for attempt in range(3):
             try:
                 existing = db.query(User).filter(User.username == username).first()
@@ -289,6 +300,9 @@ async def oidc_callback(
                     oidc_subject=sub,
                     is_active=True,
                     is_admin=False,
+                    can_download=default_can_download,
+                    auto_approve_ebooks=default_auto_approve_ebooks,
+                    auto_approve_audiobooks=default_auto_approve_audiobooks,
                 )
                 db.add(user)
                 db.commit()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -254,6 +254,9 @@ class OidcSettingsResponse(BaseModel):
     oidc_redirect_uri: OidcSettingField
     oidc_auto_register: OidcSettingField
     oidc_button_text: OidcSettingField
+    oidc_default_can_download: OidcSettingField
+    oidc_default_auto_approve_ebooks: OidcSettingField
+    oidc_default_auto_approve_audiobooks: OidcSettingField
 
 class OidcSettingsUpdate(BaseModel):
     oidc_issuer_url: Optional[str] = None
@@ -262,6 +265,9 @@ class OidcSettingsUpdate(BaseModel):
     oidc_redirect_uri: Optional[str] = None
     oidc_auto_register: Optional[str] = None
     oidc_button_text: Optional[str] = None
+    oidc_default_can_download: Optional[str] = None
+    oidc_default_auto_approve_ebooks: Optional[str] = None
+    oidc_default_auto_approve_audiobooks: Optional[str] = None
 
 @router.get("/oidc", response_model=OidcSettingsResponse)
 async def get_oidc_settings_endpoint(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -464,6 +464,9 @@ export interface OidcSettingsResponse {
   oidc_redirect_uri: OidcSettingField;
   oidc_auto_register: OidcSettingField;
   oidc_button_text: OidcSettingField;
+  oidc_default_can_download: OidcSettingField;
+  oidc_default_auto_approve_ebooks: OidcSettingField;
+  oidc_default_auto_approve_audiobooks: OidcSettingField;
 }
 
 // Auth API endpoints

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -162,6 +162,9 @@ function OidcSettingsCard() {
     oidc_redirect_uri: '',
     oidc_auto_register: 'true',
     oidc_button_text: 'Sign in with SSO',
+    oidc_default_can_download: 'false',
+    oidc_default_auto_approve_ebooks: 'false',
+    oidc_default_auto_approve_audiobooks: 'false',
   });
 
   const { data: oidcSettings, isLoading: loadingOidc } = useQuery({
@@ -178,6 +181,9 @@ function OidcSettingsCard() {
         oidc_redirect_uri: oidcSettings.oidc_redirect_uri.value || '',
         oidc_auto_register: oidcSettings.oidc_auto_register.value || 'true',
         oidc_button_text: oidcSettings.oidc_button_text.value || 'Sign in with SSO',
+        oidc_default_can_download: oidcSettings.oidc_default_can_download.value || 'false',
+        oidc_default_auto_approve_ebooks: oidcSettings.oidc_default_auto_approve_ebooks.value || 'false',
+        oidc_default_auto_approve_audiobooks: oidcSettings.oidc_default_auto_approve_audiobooks.value || 'false',
       });
     }
   }, [oidcSettings]);
@@ -222,6 +228,15 @@ function OidcSettingsCard() {
     }
     if (oidcSettings?.oidc_button_text.source !== 'env') {
       payload.oidc_button_text = formData.oidc_button_text;
+    }
+    if (oidcSettings?.oidc_default_can_download.source !== 'env') {
+      payload.oidc_default_can_download = formData.oidc_default_can_download;
+    }
+    if (oidcSettings?.oidc_default_auto_approve_ebooks.source !== 'env') {
+      payload.oidc_default_auto_approve_ebooks = formData.oidc_default_auto_approve_ebooks;
+    }
+    if (oidcSettings?.oidc_default_auto_approve_audiobooks.source !== 'env') {
+      payload.oidc_default_auto_approve_audiobooks = formData.oidc_default_auto_approve_audiobooks;
     }
     if (Object.keys(payload).length > 0) {
       saveMutation.mutate(payload);
@@ -376,6 +391,96 @@ function OidcSettingsCard() {
             />
           </div>
         </div>
+
+        {formData.oidc_auto_register === 'true' && (
+          <div className="space-y-4 rounded-lg border border-border p-4">
+            <div>
+              <Label className="text-foreground font-medium">
+                Default permissions for auto-registered users
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                Applied only when a new user account is created through OIDC.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+              <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-3">
+                <div className="space-y-0.5">
+                  <Label
+                    htmlFor="oidc-default-can-download"
+                    className="text-foreground"
+                  >
+                    Can Download
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Allow direct searching and downloads
+                  </p>
+                </div>
+                <Switch
+                  id="oidc-default-can-download"
+                  checked={formData.oidc_default_can_download === 'true'}
+                  onCheckedChange={(checked) =>
+                    setFormData(prev => ({
+                      ...prev,
+                      oidc_default_can_download: checked ? 'true' : 'false',
+                    }))
+                  }
+                  disabled={isFieldLocked('oidc_default_can_download')}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-3">
+                <div className="space-y-0.5">
+                  <Label
+                    htmlFor="oidc-default-auto-approve-ebooks"
+                    className="text-foreground"
+                  >
+                    Auto-Approve eBooks
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Automatically approve ebook requests
+                  </p>
+                </div>
+                <Switch
+                  id="oidc-default-auto-approve-ebooks"
+                  checked={formData.oidc_default_auto_approve_ebooks === 'true'}
+                  onCheckedChange={(checked) =>
+                    setFormData(prev => ({
+                      ...prev,
+                      oidc_default_auto_approve_ebooks: checked ? 'true' : 'false',
+                    }))
+                  }
+                  disabled={isFieldLocked('oidc_default_auto_approve_ebooks')}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border border-border p-3">
+                <div className="space-y-0.5">
+                  <Label
+                    htmlFor="oidc-default-auto-approve-audiobooks"
+                    className="text-foreground"
+                  >
+                    Auto-Approve Audiobooks
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Automatically approve audiobook requests
+                  </p>
+                </div>
+                <Switch
+                  id="oidc-default-auto-approve-audiobooks"
+                  checked={formData.oidc_default_auto_approve_audiobooks === 'true'}
+                  onCheckedChange={(checked) =>
+                    setFormData(prev => ({
+                      ...prev,
+                      oidc_default_auto_approve_audiobooks: checked ? 'true' : 'false',
+                    }))
+                  }
+                  disabled={isFieldLocked('oidc_default_auto_approve_audiobooks')}
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="flex justify-between pt-2">
           <Button


### PR DESCRIPTION
## Problem

Users created automatically through OIDC currently inherit Bookkeep's model defaults for request/download permissions.

Those defaults currently enable:

- Can Download
- Auto-Approve eBooks
- Auto-Approve Audiobooks

For installations using OIDC auto-registration, this means newly created SSO users receive elevated request permissions by default, with no way for an administrator to configure the desired defaults.

## Changes

Adds configurable default permissions for users created through OIDC:

- Can Download
- Auto-Approve eBooks
- Auto-Approve Audiobooks

These options are available alongside the existing OIDC settings and are applied when a new user is created through OIDC auto-registration.

The defaults are disabled unless explicitly enabled by the administrator.

Existing users are not modified.

## Testing

Tested against a live Authentik OIDC provider with automatic user registration enabled.

Verified that:

- Existing administrator permissions were unchanged
- A new OIDC user was created successfully
- The new user had Can Download disabled
- The new user had Auto-Approve eBooks disabled
- The new user had Auto-Approve Audiobooks disabled
- The settings can be independently enabled/disabled from the OIDC settings UI